### PR TITLE
Minify js and don't crash server

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,12 @@
     "gulp-open": "^0.3.1",
     "gulp-plumber": "^0.6.6",
     "gulp-rename": "^1.2.0",
+    "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.2",
     "gulp-watch": "^3.0.0",
     "rimraf": "^2.2.8",
     "run-sequence": "^1.0.2",
-    "vinyl-source-stream": "^1.0.0"
+    "vinyl-transform": "^1.0.0"
   },
   "dependencies": {
     "jquery": "^2.1.3",


### PR DESCRIPTION
The latest gulp+browserify recommendation uses vinyl-transform to wrap
the browserify stream generation as a minimal inline gulp plugin.

At the same time, it inherits the existing error handling, which
actually works.

This way I could also add uglify without have to convert streams to
buffers explicitly.
