### PR TITLE
Use strict less compilation

### DIFF
--- a/gulp/tasks/less.js
+++ b/gulp/tasks/less.js
@@ -13,7 +13,9 @@ module.exports = function(gulp, gutil) {
           'node_modules'
         ],
         rootpath: '../../',
-        relativeUrls: true
+        relativeUrls: true,
+        strictMath: true,
+        strictUnits: true
       }))
       .pipe(!prod ? gutil.noop() : csso())
       .pipe(autoprefixer({


### PR DESCRIPTION
We shouldn’t have to debug unexpected behaviour and visual bugs when
less decides that some math belongs on the browser when we usually want
it precompiled.
