### PR TITLE
Fix neverending gulp process

### DIFF
--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -2,9 +2,9 @@ var watch = require('gulp-watch');
 var livereload = require('gulp-livereload');
 
 module.exports = function(gulp) {
-  livereload.listen();
-
   gulp.task('watch', ['build'], function() {
+    livereload.listen();
+
     watch(gulp.config.source + '/styles/**/*.less', function() {
       gulp.start('less');
     });


### PR DESCRIPTION
Don't start listening to livereload port unless running `watch` task.

/cc @rthor
